### PR TITLE
[DEMO-2502] Add mysql on-host newrelic integration

### DIFF
--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
@@ -9,6 +9,29 @@
   set_fact:
     mysql_port: "{{ database_port | default(3306) }}"
 
+- name: Generate temp password
+  set_fact:
+    temp_password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
+
+- name: Save password to file (idempotent)
+  copy:
+    dest: /usr/local/etc/newrelic
+    owner: root
+    mode: 0700
+    force: false
+    content: |
+      {{ temp_password }}
+  become: true
+
+- name: Get newrelic user password from file
+  shell: cat /usr/local/etc/newrelic
+  register: command_output
+  become: true
+
+- name: Set newrelic_user_password
+  set_fact:
+      newrelic_user_password: "{{ command_output.stdout }}"
+
 - name: Check if infrastructure agent logs exist
   stat:
     path: /var/log/nr-infra.log
@@ -38,7 +61,7 @@
     login_user: "root"
     login_password: "{{ database_password }}"
     name: "newrelic"
-    password: "{{ database_password }}"
+    password: "{{ newrelic_user_password }}"
     state: present
     host: "localhost"
     priv: "*.*:GRANT,REPLICATION CLIENT"

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
@@ -64,7 +64,7 @@
     password: "{{ newrelic_user_password }}"
     state: present
     host: "localhost"
-    priv: "*.*:GRANT,REPLICATION CLIENT"
+    priv: "*.*:GRANT,REPLICATION CLIENT,SELECT"
 
 - name: Write mysql integration configuration file
   template:

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+
+- name: Ensure newrelic_license_key is defined
+  fail:
+    msg: "newrelic_license_key is required for configuring newrelic infrastructure agent"
+  when: newrelic_license_key is not defined
+
+- name: Ensure database_port is defined
+  fail:
+    msg: "database_port is required for configuring mysql integration"
+  when: database_port is not defined
+
+- name: Ensure database_password is defined
+  fail:
+    msg: "database_password is required for configuring mysql integration"
+  when: database_password is not defined
+
+- name: Check if infrastructure agent logs exist
+  stat:
+    path: /var/log/nr-infra.log
+  register: stat_result
+
+# Clear logs (from previous deployments) to avoid a false positive in the verification step.
+- name: Clear agent logs if they exist
+  shell: truncate -s 0 /var/log/nr-infra.log
+  when: stat_result.stat.exists
+  become: true
+
+- name: Run NewRelic Infrastructure Agent role
+  include_role:
+    name: newrelic.newrelic-infra
+    apply:
+      become: true
+  vars:
+    nrinfragent_config:
+      license_key: "{{ newrelic_license_key }}"
+      log_file: /var/log/nr-infra.log
+      log_to_stdout: false
+    nrinfragent_integrations:
+      - { name: nri-mysql, state: "latest" }
+
+- name: Create db user for newrelic mysql integration
+  mysql_user:
+    login_user: "root"
+    login_password: "{{ database_password }}"
+    name: "newrelic"
+    password: "{{ database_password }}"
+    state: present
+    host: "localhost"
+    priv: "*.*:GRANT,REPLICATION CLIENT"
+
+- name: Write mysql integration configuration file
+  template:
+    src: mysql-config.yml
+    dest: /etc/newrelic-infra/integrations.d/mysql-config.yml
+    owner: root
+  become: true
+
+- name: Restart newrelic infrastructure agent to pick up changes to configuration file
+  systemd:
+    name: newrelic-infra
+    state: restarted
+  become: true
+
+# Give the agent time to start up & write to log
+- name: Wait 15 seconds
+  wait_for:
+    timeout: 15
+  delegate_to: localhost
+
+- name: Verify integration is working
+  shell: cat /var/log/nr-infra.log | grep "\"Integration health check finished with success\" instance=mysql-server"
+  register: integration_status
+  failed_when: integration_status.rc != 0

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
@@ -88,13 +88,10 @@
     state: restarted
   become: true
 
-# Give the agent time to start up & write to log
-- name: Wait 15 seconds
-  wait_for:
-    timeout: 15
-  delegate_to: localhost
-
 - name: Verify integration is working
   shell: cat /var/log/nr-infra.log | grep "\"Integration health check finished with success\" instance=mysql-server"
   register: integration_status
-  failed_when: integration_status.rc != 0
+  until: integration_status.rc == 0
+  retries: 12
+  delay: 5
+  # max_wait = 12 * 5 = 60 seconds

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
@@ -32,17 +32,6 @@
   set_fact:
       newrelic_user_password: "{{ command_output.stdout }}"
 
-- name: Check if infrastructure agent logs exist
-  stat:
-    path: /var/log/nr-infra.log
-  register: stat_result
-
-# Clear logs (from previous deployments) to avoid a false positive in the verification step.
-- name: Clear agent logs if they exist
-  shell: truncate -s 0 /var/log/nr-infra.log
-  when: stat_result.stat.exists
-  become: true
-
 - name: Run NewRelic Infrastructure Agent role
   include_role:
     name: newrelic.newrelic-infra
@@ -80,6 +69,11 @@
     insertafter: 'labels:'
   loop: "{{ (tags|default({}))|dict2items }}"
   when: tags is defined
+  become: true
+
+# Clear logs (potentially from previous deployments) to avoid a false positive in the verification step.
+- name: Clear agent logs
+  shell: truncate -s 0 /var/log/nr-infra.log
   become: true
 
 - name: Restart newrelic infrastructure agent to pick up changes to configuration file

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
@@ -5,15 +5,9 @@
     msg: "newrelic_license_key is required for configuring newrelic infrastructure agent"
   when: newrelic_license_key is not defined
 
-- name: Ensure database_port is defined
-  fail:
-    msg: "database_port is required for configuring mysql integration"
-  when: database_port is not defined
-
-- name: Ensure database_password is defined
-  fail:
-    msg: "database_password is required for configuring mysql integration"
-  when: database_password is not defined
+- name: Ensure mysql_port has a value
+  set_fact:
+    mysql_port: "{{ database_port | default(3306) }}"
 
 - name: Check if infrastructure agent logs exist
   stat:

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/main.yml
@@ -73,6 +73,15 @@
     owner: root
   become: true
 
+- name: Add tags as labels to integration configuration file
+  lineinfile:
+    path: "/etc/newrelic-infra/integrations.d/mysql-config.yml"
+    line: "        {{item.key}}: {{item.value}}"
+    insertafter: 'labels:'
+  loop: "{{ (tags|default({}))|dict2items }}"
+  when: tags is defined
+  become: true
+
 - name: Restart newrelic infrastructure agent to pick up changes to configuration file
   systemd:
     name: newrelic-infra

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/templates/mysql-config.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/templates/mysql-config.yml
@@ -9,7 +9,7 @@ instances:
         hostname: localhost
         port: {{ mysql_port }}
         username: newrelic
-        password: {{ database_password }}
+        password: {{ newrelic_user_password }}
         # New users should leave this property as `true`, to identify the
         # monitored entities as `remote`. Setting this property to `false` (the
         # default value) is deprecated and will be removed soon, disallowing

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/templates/mysql-config.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/templates/mysql-config.yml
@@ -24,5 +24,3 @@ instances:
         extended_innodb_metrics: 1
         extended_myisam_metrics: 1
     labels:
-        env: production
-        role: write-replica

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/templates/mysql-config.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/templates/mysql-config.yml
@@ -7,7 +7,7 @@ instances:
     command: status
     arguments:
         hostname: localhost
-        port: {{ database_port }}
+        port: {{ mysql_port }}
         username: newrelic
         password: {{ database_password }}
         # New users should leave this property as `true`, to identify the

--- a/deploy/databases/linux/mysql/roles/onafterstart/tasks/templates/mysql-config.yml
+++ b/deploy/databases/linux/mysql/roles/onafterstart/tasks/templates/mysql-config.yml
@@ -1,0 +1,28 @@
+---
+
+integration_name: com.newrelic.mysql
+
+instances:
+  - name: mysql-server
+    command: status
+    arguments:
+        hostname: localhost
+        port: {{ database_port }}
+        username: newrelic
+        password: {{ database_password }}
+        # New users should leave this property as `true`, to identify the
+        # monitored entities as `remote`. Setting this property to `false` (the
+        # default value) is deprecated and will be removed soon, disallowing
+        # entities that are identified as `local`.
+        # Please check the documentation to get more information about local
+        # versus remote entities:
+        # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
+        remote_monitoring: true
+        # Value of '1' indicates the gathering of the metrics below are enabled. 
+        # They are disabled by default.
+        extended_metrics: 1
+        extended_innodb_metrics: 1
+        extended_myisam_metrics: 1
+    labels:
+        env: production
+        role: write-replica


### PR DESCRIPTION
* Added the tasks & template for installing the integration, as well as
verifying that it works once installed. The integration installation
uses the public new relic infra ansible role.
* The role is 'onafterstart' because this needs mysql to be installed.
The installation of mysql occurs in 'start', so this must follow that.